### PR TITLE
Moved StrongNamer to before MarkupCompilePass1

### DIFF
--- a/src/StrongNamer/StrongNamer.targets
+++ b/src/StrongNamer/StrongNamer.targets
@@ -3,7 +3,7 @@
   <UsingTask TaskName="StrongNamer.AddStrongName" AssemblyFile="$(MSBuildThisFileDirectory)StrongNamer.dll" />
 
   <Target Name="StrongNamerTarget"
-          AfterTargets="AfterBuild">
+          AfterTargets="AfterResolveReferences">
 
     <StrongNamer.AddStrongName
           Assemblies="@(ReferencePath)"
@@ -27,7 +27,7 @@
   </Target>
 
   <PropertyGroup>
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);StrongNamerTarget</CoreCompileDependsOn>
+    <ResolveReferencesDependsOn>$(ResolveReferencesDependsOn);StrongNamerTarget</ResolveReferencesDependsOn>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This project would have saved me so much time. Unfortunately it didn't work with my project and I ended up wasting more time trying to fix it. Typical programmer. ;)

Anyway, when using this with a 2 pass xaml compile project the typical compile order is MarkupCompilePass1 -> csc -> MarkupCompilePass2. StrongNamer runs right before the compiler step, but after MarkupCompilePass1. For some reason MarkupCompilePass2 was then using the old references, not the strong named ones.

So this PR changes the target file to move the StrongNamer task to right after the references are resolved, before the MarkupCompilePass1 step, which fixed the problem for me.