### PR TITLE
Allow for conditional signing of assemblies based off of a build-time variable

### DIFF
--- a/src/StrongNamer/StrongNamer.targets
+++ b/src/StrongNamer/StrongNamer.targets
@@ -3,7 +3,8 @@
   <UsingTask TaskName="StrongNamer.AddStrongName" AssemblyFile="$(MSBuildThisFileDirectory)StrongNamer.dll" />
 
   <Target Name="StrongNamerTarget"
-          AfterTargets="AfterResolveReferences">
+          AfterTargets="AfterResolveReferences"
+          Condition="'$(DisableStrongNamer)' != 'true'">
 
     <StrongNamer.AddStrongName
           Assemblies="@(ReferencePath)"


### PR DESCRIPTION
Depending on build configuration (e.g., different environments), users may want to enable or disable the automated signing of unsigned packages.  This simple change allows for this.

If DisableStrongNamer isn't set, assemblies will still be signed, which ensures backwards compatibility.