### PR TITLE
Allow for conditional signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ just before they are passed to the compiler.
 
 The task uses Mono.Cecil to do this.  Credit goes to [Nivot.StrongNaming](https://github.com/oising/strongnaming) for showing me how
 to do this.
+
+# Options
+
+You can conditionally disable automated signing of unsigned packages by setting the "DisableStrongNamer" property to "true".  This is particularly useful if you have a custom build configuration for your application (e.g., you only wish for unsigned packages to be autosigned in specific environments).

--- a/src/StrongNamer/StrongNamer.targets
+++ b/src/StrongNamer/StrongNamer.targets
@@ -3,7 +3,8 @@
   <UsingTask TaskName="StrongNamer.AddStrongName" AssemblyFile="$(MSBuildThisFileDirectory)StrongNamer.dll" />
 
   <Target Name="StrongNamerTarget"
-          AfterTargets="AfterResolveReferences">
+          AfterTargets="AfterResolveReferences"
+          Condition="'$(DisableStrongNamer)' != 'true'">
 
     <StrongNamer.AddStrongName
           Assemblies="@(ReferencePath)"


### PR DESCRIPTION
Depending on build configuration (e.g., different environments), users may want to enable or disable the automated signing of unsigned packages. This simple change allows for this.

If DisableStrongNamer isn't set, assemblies will still be signed, which ensures backwards compatibility.