### PR TITLE
Fix for #11 - Adds StrongNamerAssemblyResolver

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -33,7 +33,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <Build>3</Build>
+    <Build>4</Build>
     <Revision>0</Revision>
 
     

--- a/common/CommonAssemblyInfo.cs
+++ b/common/CommonAssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 //  No need to manually update this, build process does it automatically
-[assembly: AssemblyVersion("0.0.3.0")]
-[assembly: AssemblyFileVersion("0.0.3.0")]
+[assembly: AssemblyVersion("0.0.4.0")]
+[assembly: AssemblyFileVersion("0.0.4.0")]

--- a/src/StrongNamer/AddStrongName.cs
+++ b/src/StrongNamer/AddStrongName.cs
@@ -38,9 +38,8 @@ namespace StrongNamer
             {
                 if (_assemblyResolver == null)
                 {
-                    _assemblyResolver = new StrongNamerAssemblyResolver(Assemblies
-                        .Select(ti => AssemblyDefinition.ReadAssembly(ti.ItemSpec))
-                        .ToList());
+                    _assemblyResolver = new StrongNamerAssemblyResolver(
+                        Assemblies.Select(a => a.ItemSpec));
                 }
                 return _assemblyResolver;
             }

--- a/src/StrongNamer/AddStrongName.cs
+++ b/src/StrongNamer/AddStrongName.cs
@@ -32,6 +32,21 @@ namespace StrongNamer
         [Required]
         public ITaskItem KeyFile { get; set; }
 
+        StrongNamerAssemblyResolver AssemblyResolver
+        {
+            get
+            {
+                if (_assemblyResolver == null)
+                {
+                    _assemblyResolver = new StrongNamerAssemblyResolver(Assemblies
+                        .Select(ti => AssemblyDefinition.ReadAssembly(ti.ItemSpec))
+                        .ToList());
+                }
+                return _assemblyResolver;
+            }
+        }
+        StrongNamerAssemblyResolver _assemblyResolver;
+
         public override bool Execute()
         {
             if (Assemblies == null || Assemblies.Length == 0)
@@ -100,7 +115,10 @@ namespace StrongNamer
 
         ITaskItem ProcessAssembly(ITaskItem assemblyItem, StrongNameKeyPair key)
         {
-            var assembly = AssemblyDefinition.ReadAssembly(assemblyItem.ItemSpec);
+            var assembly = AssemblyDefinition.ReadAssembly(assemblyItem.ItemSpec, new ReaderParameters()
+            {
+                AssemblyResolver = this.AssemblyResolver
+            });
 
             if (assembly.Name.HasPublicKey)
             {

--- a/src/StrongNamer/AddStrongName.cs
+++ b/src/StrongNamer/AddStrongName.cs
@@ -109,6 +109,8 @@ namespace StrongNamer
                 }
             }
 
+            AssemblyResolver.Dispose(false);
+
             return true;
         }
 

--- a/src/StrongNamer/StrongNamer.csproj
+++ b/src/StrongNamer/StrongNamer.csproj
@@ -48,6 +48,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AddStrongName.cs" />
+    <Compile Include="StrongNamerAssemblyResolver.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/StrongNamer/StrongNamerAssemblyResolver.cs
+++ b/src/StrongNamer/StrongNamerAssemblyResolver.cs
@@ -34,5 +34,12 @@ namespace StrongNamer
         {
             return Resolve(name, new ReaderParameters());
         }
+
+        public new void Dispose(bool disposing) {
+            base.Dispose(disposing);
+            for (int i = 0; i < _assemblies.Count; i++) {
+                _assemblies.ElementAtOrDefault(i)?.Dispose();
+            }
+        }
     }
 }

--- a/src/StrongNamer/StrongNamerAssemblyResolver.cs
+++ b/src/StrongNamer/StrongNamerAssemblyResolver.cs
@@ -9,11 +9,13 @@ namespace StrongNamer
 {
     class StrongNamerAssemblyResolver : BaseAssemblyResolver
     {
-        List<AssemblyDefinition> _assemblies = new List<AssemblyDefinition>();
+        readonly List<AssemblyDefinition> _assemblies = null;
 
-        public StrongNamerAssemblyResolver(List<AssemblyDefinition> assemblies) : base()
+        public StrongNamerAssemblyResolver(IEnumerable<string> assemblyPaths) : base()
         {
-            _assemblies = assemblies;
+            _assemblies = assemblyPaths
+                .Select(path => AssemblyDefinition.ReadAssembly(path))
+                .ToList();
         }
 
         // Check the StrongNamer knowledge of assemblies before passing to the base resolver.

--- a/src/StrongNamer/StrongNamerAssemblyResolver.cs
+++ b/src/StrongNamer/StrongNamerAssemblyResolver.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Cecil;
+
+namespace StrongNamer
+{
+    class StrongNamerAssemblyResolver : BaseAssemblyResolver
+    {
+        List<AssemblyDefinition> _assemblies = new List<AssemblyDefinition>();
+
+        public StrongNamerAssemblyResolver(List<AssemblyDefinition> assemblies) : base()
+        {
+            _assemblies = assemblies;
+        }
+
+        // Check the StrongNamer knowledge of assemblies before passing to the base resolver.
+        // Base resolver checks local folders and the GAC, so will not find anything in the Packages folder
+        public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            var matchedAssembly = _assemblies.SingleOrDefault(ad => ad.Name.Name.Equals(name.Name));
+            if (matchedAssembly == null)
+            {
+                return base.Resolve(name, parameters);
+            }
+            return matchedAssembly;
+        }
+
+        public override AssemblyDefinition Resolve(AssemblyNameReference name)
+        {
+            return Resolve(name, new ReaderParameters());
+        }
+    }
+}


### PR DESCRIPTION
Hey Daniel,

I've recently been wrangling with a build-blocking bug which is detailed in #11 and researched in #10.

Whenever a compile-time constant based on a type defined in a second-order dependency was found by Mono.Cecil, it would go looking for the second-order assembly in order to validate the original type. Because the DefaultAssemblyResolver and BaseAssemblyResolver only look through following: `'.', 'bin', GAC, Resolver Cache` this was failing when the second-order dependency was a package or custom dll.

This PR fixes this by providing `StrongNamerAssemblyResolver` which stores a list of pre-read assemblies to compare their name against a requested assembly.

Name alone may not be the best way to go about this, but I look to your experience for confirmation of this.

I have got this built on an internal nuget repo, so no major rush from me to have this merged.