### PR TITLE
Avoid work if signed assembly already exists.

### DIFF
--- a/common/CommonAssemblyInfo.cs
+++ b/common/CommonAssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 
 //  No need to manually update this, build process does it automatically
-[assembly: AssemblyVersion("0.0.4.0")]
-[assembly: AssemblyFileVersion("0.0.4.0")]
+[assembly: AssemblyVersion("0.0.5.0")]
+[assembly: AssemblyFileVersion("0.0.5.0")]


### PR DESCRIPTION
If the signed assembly folder already contains the output assembly and its Mvid matches the Mvid of the current assembly, avoid all the work and just use the existing output assembly.

This helps with performance and also build incrementality. If the output assembly is not touched unnecessarily it's timestamp won't change and it won't invalidate the rest of the build as it currently does.