### PR TITLE
Allow custom key file

### DIFF
--- a/src/StrongNamer/StrongNamer.targets
+++ b/src/StrongNamer/StrongNamer.targets
@@ -6,11 +6,15 @@
           AfterTargets="AfterResolveReferences"
           Condition="'$(DisableStrongNamer)' != 'true'">
 
+    <PropertyGroup>
+	<StrongNamerKeyFile Condition="'$(StrongNamerKeyFile)'==''">$(MSBuildThisFileDirectory)SharedKey.snk</StrongNamerKeyFile>
+    </PropertyGroup>
+
     <StrongNamer.AddStrongName
           Assemblies="@(ReferencePath)"
           CopyLocalFiles="@(ReferenceCopyLocalPaths)"
           SignedAssemblyFolder="$(IntermediateOutputPath)SignedAssemblies"
-          KeyFile="$(MSBuildThisFileDirectory)SharedKey.snk">
+          KeyFile="$(StrongNamerKeyFile)">
 
       <Output TaskParameter="SignedAssembliesToReference" ItemName="AssembliesToReference" />
       <Output TaskParameter="NewCopyLocalFiles" ItemName="NewCopyLocalFiles" />


### PR DESCRIPTION
Allow the usage of a custom key file by defining the
`StrongNamerKeyFile` property. If that property isn't set, it defaults
to `SharedKey.snk`.

This helps scenarios with `InternalsVisibleTo` attributes.

Fixes #21