### PR TITLE
Fix for FileNotFoundException on unbuilt ProjectReferences

### DIFF
--- a/src/StrongNamer/AddStrongName.cs
+++ b/src/StrongNamer/AddStrongName.cs
@@ -124,6 +124,12 @@ namespace StrongNamer
                 }
             }
 
+            if (!File.Exists(assemblyItem.ItemSpec))
+            {
+                Log.LogMessage(MessageImportance.Low, $"Assembly file '{assemblyItem.ItemSpec}' does not exist (yet).  Skipping.");
+                return assemblyItem;
+            }
+
             using (var assembly = AssemblyDefinition.ReadAssembly(assemblyItem.ItemSpec, new ReaderParameters()
             {
                 AssemblyResolver = resolver

--- a/src/StrongNamer/StrongNamerAssemblyResolver.cs
+++ b/src/StrongNamer/StrongNamerAssemblyResolver.cs
@@ -19,7 +19,15 @@ namespace StrongNamer
         // Base resolver checks local folders and the GAC, so will not find anything in the Packages folder
         public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
         {
-            var matchedAssembly = base.Resolve(name, parameters);
+            AssemblyDefinition matchedAssembly = null;
+            try
+            {
+                matchedAssembly = base.Resolve(name, parameters);
+            }
+            catch (AssemblyResolutionException)
+            {
+            }
+
             if (matchedAssembly == null)
             {
                 if (_assemblies == null)

--- a/src/StrongNamer/project.json
+++ b/src/StrongNamer/project.json
@@ -1,13 +1,13 @@
 ﻿{
   "dependencies": {
-    "Mono.Cecil": "0.10.0-beta2"
+    "Mono.Cecil": "0.10.0"
   },
   "frameworks": {
     "net452": {
-      "dependencies": { }
+      "dependencies": {}
     }
   },
   "runtimes": {
-    "win-any": { }
+    "win-any": {}
   }
 }


### PR DESCRIPTION
Fixes #27.

StrongNamerAssemblyResolver: ignore assemblyPaths which don't exist.  Also defer reading the assemblies until they are actually needed (when the base resolver failed).

AddStrongName.ProcessAssembly: ignore assemblyItem whose path doesn't exist.  Emit log message.

If you don't want the update to Mono.Cecil 0.10.0, I can remove it from the PR.