### PR TITLE
Define StrongNamer as a development-only dependency

### DIFF
--- a/common/StrongNamer.nuspec
+++ b/common/StrongNamer.nuspec
@@ -15,6 +15,7 @@
         <description>Strong Namer will automatically add strong names to referenced assemblies which do not already have a strong name.  This will allow you to reference and use NuGet packages with assemblies which are not strong named from your projects that do use a strong name.</description>
         <summary>Strong Namer will automatically add strong names to referenced assemblies which do not already have a strong name.</summary>
         <tags>strongname strong name naming</tags>
+        <developmentDependency>true</developmentDependency>
     </metadata>
     <files>
       <file src="StrongNamer.dll" target="build" />


### PR DESCRIPTION
When an assembly that is later packed into a nuget package makes use of Strongnamer, it is listed as part of the package dependency tree. 

We don't want that as consumers of the package should not retrieve a copy of Strongnamer.